### PR TITLE
fix: allocating incorrect max value due to missing parentheses

### DIFF
--- a/backend/functions/src/services/puppeteer.ts
+++ b/backend/functions/src/services/puppeteer.ts
@@ -74,7 +74,7 @@ export class PuppeteerControl extends AsyncService {
             return page.browser().connected && !page.isClosed();
         }
     }, {
-        max: Math.max(1 + Math.floor(os.freemem() / 1024 * 1024 * 1024), 16),
+        max: Math.max(1 + Math.floor(os.freemem() / (1024 * 1024 * 1024)), 16),
         min: 1,
         acquireTimeoutMillis: 60_000,
         testOnBorrow: true,


### PR DESCRIPTION
I assume you want to set max value to per GB in free memory or 16

```shell
> Math.max(1 + Math.floor(os.freemem() / 1024 * 1024 * 1024), 16)
6100229292033
> Math.max(1 + Math.floor(os.freemem() / (1024 * 1024 * 1024)), 16)
16
```