### PR TITLE
fix: consider image data-src and make generated alt text optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ As you have already seen above, one can control the behavior of the Reader API u
   - `x-respond-with: screenshot` returns the URL of the webpage's screenshot
 - You can specify a proxy server via the `x-proxy-url` header.
 - You can bypass the cached page (lifetime 300s) via the `x-no-cache` header.
+- You can enable alt-text generation feature via the `x-with-generated-alt` header.
 
 ### JSON mode (super early beta)
 

--- a/backend/functions/package-lock.json
+++ b/backend/functions/package-lock.json
@@ -178,6 +178,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -6251,6 +6261,17 @@
         "node": ">=10.19.0"
       }
     },
+    "node_modules/http2-wrapper/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -8059,16 +8080,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/lru-memoizer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.2.0.tgz",
@@ -9851,17 +9862,6 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "optional": true
-    },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",

--- a/backend/functions/src/cloud-functions/crawler.ts
+++ b/backend/functions/src/cloud-functions/crawler.ts
@@ -122,7 +122,7 @@ export class CrawlerHost extends RPCHost {
         }
         const urlToAltMap: { [k: string]: string | undefined; } = {};
         if (snapshot.imgs?.length && this.threadLocal.get('withGeneratedAlt')) {
-            const tasks = (snapshot.imgs || []).map(async (x) => {
+            const tasks = _.uniqBy((snapshot.imgs || []), 'src').map(async (x) => {
                 const r = await this.altTextService.getAltText(x).catch((err: any) => {
                     this.logger.warn(`Failed to get alt text for ${x.src}`, { err: marshalErrorLike(err) });
                     return undefined;

--- a/backend/functions/src/cloud-functions/crawler.ts
+++ b/backend/functions/src/cloud-functions/crawler.ts
@@ -291,6 +291,11 @@ ${this.content}
                         in: 'header',
                         schema: { type: 'string' }
                     },
+                    'X-With-Generated-Alt': {
+                        description: `Enable automatic alt-text generating for images without an meaningful alt-text.`,
+                        in: 'header',
+                        schema: { type: 'string' }
+                    },
                 }
             }
         },

--- a/backend/functions/src/services/alt-text.ts
+++ b/backend/functions/src/services/alt-text.ts
@@ -12,6 +12,7 @@ const md5Hasher = new HashManager('md5', 'hex');
 @singleton()
 export class AltTextService extends AsyncService {
 
+    nonsenseAlts = 'image,img,photo,picture,pic,alt'.split(',');
     logger = this.globalLogger.child({ service: this.constructor.name });
 
     constructor(
@@ -48,7 +49,7 @@ export class AltTextService extends AsyncService {
         if (!imgBrief.src) {
             return undefined;
         }
-        if (imgBrief.alt) {
+        if (imgBrief.alt && !this.nonsenseAlts.includes(imgBrief.alt.trim().toLowerCase())) {
             return imgBrief.alt;
         }
         const digest = md5Hasher.hash(imgBrief.src);

--- a/backend/functions/src/services/alt-text.ts
+++ b/backend/functions/src/services/alt-text.ts
@@ -12,7 +12,7 @@ const md5Hasher = new HashManager('md5', 'hex');
 @singleton()
 export class AltTextService extends AsyncService {
 
-    nonsenseAlts = 'image,img,photo,picture,pic,alt'.split(',');
+    altsToIgnore = 'image,img,photo,picture,pic,alt,figure,fig'.split(',');
     logger = this.globalLogger.child({ service: this.constructor.name });
 
     constructor(
@@ -49,7 +49,7 @@ export class AltTextService extends AsyncService {
         if (!imgBrief.src) {
             return undefined;
         }
-        if (imgBrief.alt && !this.nonsenseAlts.includes(imgBrief.alt.trim().toLowerCase())) {
+        if (imgBrief.alt && !this.altsToIgnore.includes(imgBrief.alt.trim().toLowerCase())) {
             return imgBrief.alt;
         }
         const digest = md5Hasher.hash(imgBrief.src);

--- a/backend/functions/src/services/puppeteer.ts
+++ b/backend/functions/src/services/puppeteer.ts
@@ -193,17 +193,26 @@ export class PuppeteerControl extends AsyncService {
         preparations.push(page.evaluateOnNewDocument(READABILITY_JS));
         preparations.push(page.evaluateOnNewDocument(`
 function briefImgs(elem) {
-    const imageTags = Array.from((elem || document).querySelectorAll('img[src]'));
+    const imageTags = Array.from((elem || document).querySelectorAll('img[src],img[data-src]'));
 
-    return imageTags.map((x)=> ({
-        src: x.src,
-        loaded: x.complete,
-        width: x.width,
-        height: x.height,
-        naturalWidth: x.naturalWidth,
-        naturalHeight: x.naturalHeight,
-        alt: x.alt || x.title,
-    }));
+    return imageTags.map((x)=> {
+        let linkPreferredSrc = x.src;
+        if (linkPreferredSrc.startsWith('data:')) {
+            if (typeof x.dataset?.src === 'string' && !x.dataset.src.startsWith('data:')) {
+                linkPreferredSrc = x.dataset.src;
+            }
+        }
+
+        return {
+            src: linkPreferredSrc,
+            loaded: x.complete,
+            width: x.width,
+            height: x.height,
+            naturalWidth: x.naturalWidth,
+            naturalHeight: x.naturalHeight,
+            alt: x.alt || x.title,
+        };
+    });
 }
 function giveSnapshot() {
     let parsed;


### PR DESCRIPTION
- Consider `img[data-src]` if `img[src]` is data url
- Make generated alt optional and non-default
  - Re-enable generated alt by setting the `x-with-generated-alt` header.