### PR TITLE
fix: add to the non Public CIDRs

### DIFF
--- a/src/utils/ip.ts
+++ b/src/utils/ip.ts
@@ -129,6 +129,7 @@ export class CIDR {
 }
 
 const nonPublicNetworks4 = [
+    '0.0.0.0',
     '10.0.0.0/8',
     '172.16.0.0/12',
     '192.168.0.0/16',


### PR DESCRIPTION
I found that 0.0.0.0 is not restricted here, which may cause SSRF security issues. For example, I found an intranet port 8081, which can be successfully responsed.

[https://r.jina.ai/0.0.0.0:8081](https://r.jina.ai/0.0.0.0:8081)