### PR TITLE
fix: reject hostnames that resolve to non-public IPs

### DIFF
--- a/src/services/misc.ts
+++ b/src/services/misc.ts
@@ -2,9 +2,10 @@ import { singleton } from 'tsyringe';
 import { AsyncService } from 'civkit/async-service';
 import { ParamValidationError } from 'civkit/civ-rpc';
 import { isIP } from 'node:net';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import type { LookupAddress } from 'node:dns';
 import { isIPInNonPublicRange } from '../utils/ip';
 import { GlobalLogger } from './logger';
-import { lookup } from 'node:dns/promises';
 import { Threaded } from './threaded';
 import { SecurityCompromiseError } from './errors';
 import { GeoIPService } from './geoip';
@@ -13,6 +14,109 @@ import _ from 'lodash';
 const normalizeUrl = require('@esm2cjs/normalize-url').default;
 
 export const privateIpNotAcceptable = Boolean(process.env['NODE_ENV']?.toLowerCase()?.includes('prod') && process.env['GCLOUD_PROJECT']);
+
+export type DnsLookupAll = (hostname: string, options: { all: true }) => Promise<LookupAddress[]>;
+
+export type AssertNormalizedUrlContext = {
+    logger: { warn: (msg: string, extra?: Record<string, unknown>) => void };
+    geoIpService: { lookupCities: (ips: string[]) => Promise<Array<{ country?: { code?: string } }>> };
+    lookup?: DnsLookupAll;
+};
+
+/**
+ * Core URL normalization + SSRF checks. Kept undecorated so unit tests can inject
+ * a DNS lookup without going through the @Threaded worker pool.
+ */
+export async function assertNormalizedUrlImpl(input: string, ctx: AssertNormalizedUrlContext) {
+    const lookup = ctx.lookup ?? ((hostname: string, options: { all: true }) => dnsLookup(hostname, options));
+    let result: URL;
+    try {
+        result = new URL(
+            normalizeUrl(
+                input,
+                {
+                    stripWWW: false,
+                    removeTrailingSlash: false,
+                    removeSingleSlash: false,
+                    sortQueryParameters: false,
+                }
+            )
+        );
+    } catch (err) {
+        throw new ParamValidationError({
+            message: `${err}`,
+            path: 'url'
+        });
+    }
+
+    if (!['http:', 'https:', 'blob:'].includes(result.protocol)) {
+        throw new ParamValidationError({
+            message: `Invalid protocol ${result.protocol}`,
+            path: 'url'
+        });
+    }
+
+    const normalizedHostname = result.hostname.startsWith('[') ? result.hostname.slice(1, -1) : result.hostname;
+    let ips: string[] = [];
+    const isIp = isIP(normalizedHostname);
+    if (isIp) {
+        ips.push(normalizedHostname);
+    }
+    if (
+        privateIpNotAcceptable &&
+        (result.hostname === 'localhost') ||
+        (isIp && isIPInNonPublicRange(normalizedHostname))
+    ) {
+        ctx.logger.warn(`Suspicious action: Request to localhost or non-public IP: ${normalizedHostname}`, { href: result.href });
+        throw new SecurityCompromiseError({
+            message: `Suspicious action: Request to localhost or non-public IP: ${normalizedHostname}`,
+            path: 'url'
+        });
+    }
+    if (!isIp && result.protocol !== 'blob:') {
+        const resolved = await lookup(result.hostname, { all: true }).catch((err) => {
+            if (err.code === 'ENOTFOUND') {
+                return Promise.reject(new ParamValidationError({
+                    message: `Domain '${result.hostname}' could not be resolved`,
+                    path: 'url'
+                }));
+            }
+
+            return;
+        });
+        if (resolved) {
+            for (const x of resolved) {
+                if (isIPInNonPublicRange(x.address)) {
+                    ctx.logger.warn(`Suspicious action: Domain resolved to non-public IP: ${result.hostname} => ${x.address}`, { href: result.href, ip: x.address });
+                    throw new SecurityCompromiseError({
+                        message: `Suspicious action: Domain resolved to non-public IP: ${x.address}`,
+                        path: 'url'
+                    });
+                }
+                ips.push(x.address);
+            }
+
+        }
+    }
+
+    let hintCountry: string | undefined;
+    if (ips.length) {
+        const hints = await ctx.geoIpService.lookupCities(ips);
+        const board: Record<string, number> = {};
+        for (const x of hints) {
+            if (x.country?.code) {
+                board[x.country.code] = (board[x.country.code] || 0) + 1;
+            }
+        }
+        hintCountry = _.maxBy(Array.from(Object.entries(board)), 1)?.[0];
+    }
+
+    return {
+        url: result,
+        ips,
+        hintCountry,
+    };
+}
 
 @singleton()
 export class MiscService extends AsyncService {
@@ -34,93 +138,10 @@ export class MiscService extends AsyncService {
 
     @Threaded()
     async assertNormalizedUrl(input: string) {
-        let result: URL;
-        try {
-            result = new URL(
-                normalizeUrl(
-                    input,
-                    {
-                        stripWWW: false,
-                        removeTrailingSlash: false,
-                        removeSingleSlash: false,
-                        sortQueryParameters: false,
-                    }
-                )
-            );
-        } catch (err) {
-            throw new ParamValidationError({
-                message: `${err}`,
-                path: 'url'
-            });
-        }
-
-        if (!['http:', 'https:', 'blob:'].includes(result.protocol)) {
-            throw new ParamValidationError({
-                message: `Invalid protocol ${result.protocol}`,
-                path: 'url'
-            });
-        }
-
-        const normalizedHostname = result.hostname.startsWith('[') ? result.hostname.slice(1, -1) : result.hostname;
-        let ips: string[] = [];
-        const isIp = isIP(normalizedHostname);
-        if (isIp) {
-            ips.push(normalizedHostname);
-        }
-        if (
-            privateIpNotAcceptable &&
-            (result.hostname === 'localhost') ||
-            (isIp && isIPInNonPublicRange(normalizedHostname))
-        ) {
-            this.logger.warn(`Suspicious action: Request to localhost or non-public IP: ${normalizedHostname}`, { href: result.href });
-            throw new SecurityCompromiseError({
-                message: `Suspicious action: Request to localhost or non-public IP: ${normalizedHostname}`,
-                path: 'url'
-            });
-        }
-        if (!isIp && result.protocol !== 'blob:') {
-            const resolved = await lookup(result.hostname, { all: true }).catch((err) => {
-                if (err.code === 'ENOTFOUND') {
-                    return Promise.reject(new ParamValidationError({
-                        message: `Domain '${result.hostname}' could not be resolved`,
-                        path: 'url'
-                    }));
-                }
-
-                return;
-            });
-            if (resolved) {
-                for (const x of resolved) {
-                    if (privateIpNotAcceptable && isIPInNonPublicRange(x.address)) {
-                        this.logger.warn(`Suspicious action: Domain resolved to non-public IP: ${result.hostname} => ${x.address}`, { href: result.href, ip: x.address });
-                        throw new SecurityCompromiseError({
-                            message: `Suspicious action: Domain resolved to non-public IP: ${x.address}`,
-                            path: 'url'
-                        });
-                    }
-                    ips.push(x.address);
-                }
-
-            }
-        }
-
-        let hintCountry: string | undefined;
-        if (ips.length) {
-            const hints = await this.geoIpService.lookupCities(ips);
-            const board: Record<string, number> = {};
-            for (const x of hints) {
-                if (x.country?.code) {
-                    board[x.country.code] = (board[x.country.code] || 0) + 1;
-                }
-            }
-            hintCountry = _.maxBy(Array.from(Object.entries(board)), 1)?.[0];
-        }
-
-        return {
-            url: result,
-            ips,
-            hintCountry,
-        };
+        return assertNormalizedUrlImpl(input, {
+            logger: this.logger,
+            geoIpService: this.geoIpService,
+        });
     }
 
 }

--- a/tests/unit/assert-normalized-url.test.ts
+++ b/tests/unit/assert-normalized-url.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for assertNormalizedUrlImpl SSRF checks on DNS-resolved IPs.
+ *
+ * Self-hosted / non-prod (no GCLOUD_PROJECT, NODE_ENV not prod) used to skip the
+ * resolved-IP check because it was gated on `privateIpNotAcceptable`. Direct IP
+ * literals in non-public ranges are already rejected; these tests cover hostnames
+ * whose A/AAAA records point at private, link-local, or metadata addresses.
+ *
+ * DNS is injected — no live lookups and no exploit PoC.
+ */
+import 'reflect-metadata';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { LookupAddress } from 'node:dns';
+import { assertNormalizedUrlImpl, privateIpNotAcceptable } from '../../build/services/misc.js';
+import { SecurityCompromiseError } from '../../build/services/errors.js';
+
+function mkCtx(addresses: LookupAddress[]) {
+    const lookupCalls: string[] = [];
+    return {
+        lookupCalls,
+        ctx: {
+            logger: {
+                warn() { /* no-op */ },
+            },
+            geoIpService: {
+                lookupCities: async () => [],
+            },
+            lookup: async (hostname: string, _opts: { all: true }) => {
+                lookupCalls.push(hostname);
+                return addresses;
+            },
+        },
+    };
+}
+
+describe('assertNormalizedUrlImpl: self-hosted resolved-IP SSRF guard', () => {
+    it('runs with privateIpNotAcceptable false (no GCLOUD_PROJECT / non-prod)', () => {
+        assert.equal(privateIpNotAcceptable, false);
+        assert.equal(process.env['GCLOUD_PROJECT'], undefined);
+    });
+
+    it('rejects a hostname that resolves to an RFC1918 address', async () => {
+        const { ctx, lookupCalls } = mkCtx([{ address: '10.0.0.1', family: 4 }]);
+        await assert.rejects(
+            () => assertNormalizedUrlImpl('http://internal.example.test/', ctx),
+            (err: unknown) => {
+                assert.ok(err instanceof SecurityCompromiseError);
+                assert.match((err as Error).message, /non-public IP: 10\.0\.0\.1/);
+                return true;
+            }
+        );
+        assert.deepEqual(lookupCalls, ['internal.example.test']);
+    });
+
+    it('rejects a hostname that resolves to a link-local / metadata address', async () => {
+        const { ctx } = mkCtx([{ address: '169.254.169.254', family: 4 }]);
+        await assert.rejects(
+            () => assertNormalizedUrlImpl('http://metadata.example.test/', ctx),
+            (err: unknown) => {
+                assert.ok(err instanceof SecurityCompromiseError);
+                assert.match((err as Error).message, /non-public IP: 169\.254\.169\.254/);
+                return true;
+            }
+        );
+    });
+
+    it('rejects a hostname that resolves to an IPv6 unique-local address', async () => {
+        const { ctx } = mkCtx([{ address: 'fd00::1', family: 6 }]);
+        await assert.rejects(
+            () => assertNormalizedUrlImpl('http://ula.example.test/', ctx),
+            (err: unknown) => {
+                assert.ok(err instanceof SecurityCompromiseError);
+                assert.match((err as Error).message, /non-public IP: fd00::1/);
+                return true;
+            }
+        );
+    });
+
+    it('rejects when any resolved record is non-public', async () => {
+        const { ctx } = mkCtx([
+            { address: '8.8.8.8', family: 4 },
+            { address: '192.168.1.20', family: 4 },
+        ]);
+        await assert.rejects(
+            () => assertNormalizedUrlImpl('http://mixed.example.test/', ctx),
+            SecurityCompromiseError
+        );
+    });
+
+    it('allows a hostname that resolves only to a public address', async () => {
+        const { ctx } = mkCtx([{ address: '8.8.8.8', family: 4 }]);
+        const result = await assertNormalizedUrlImpl('http://public.example.test/', ctx);
+        assert.equal(result.url.hostname, 'public.example.test');
+        assert.deepEqual(result.ips, ['8.8.8.8']);
+    });
+});


### PR DESCRIPTION
Self-hosted deployments skipped the DNS-resolved IP check because it was gated on privateIpNotAcceptable (prod + GCLOUD_PROJECT). A hostname that resolves to a private, link-local, or unique-local address is now rejected the same way a literal non-public IP already is.

Fixes #1253